### PR TITLE
CDI 1.1 does not allow BeanManager.getBeans() to be called during AfterB...

### DIFF
--- a/src/main/java/org/vaadin/addon/cdimvp/MVPExtension.java
+++ b/src/main/java/org/vaadin/addon/cdimvp/MVPExtension.java
@@ -6,11 +6,16 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.enterprise.event.Observes;
 import javax.enterprise.event.Reception;
 import javax.enterprise.event.TransactionPhase;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.ProcessBean;
+import javax.enterprise.inject.spi.ProcessManagedBean;
+import javax.enterprise.inject.spi.AfterDeploymentValidation;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.Extension;
@@ -21,10 +26,68 @@ import org.vaadin.addon.cdimvp.CDIEvent.CDIEventImpl;
 
 @SuppressWarnings("serial")
 public class MVPExtension implements Extension, Serializable {
+
+    private static final Logger LOGGER = Logger.getLogger(MVPExtension.class.getName());
+    private java.util.Set<Bean<?>> presenterBeans
+            = new java.util.HashSet<Bean<?>>();
+
+    /**
+     * Cdi 1.1 , It is safe to call getBeans on AfterDeploymentValidation
+     */
+    void afterDeploymentValidation(@Observes final AfterDeploymentValidation event,
+            final BeanManager beanManager) {
+
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST, "MVPExtension.afterDeploymentValidation");
+        }
+        // Check that all MVPPresenter Beans are annotated with ViewInterface
+        final Iterator<Bean<?>> beanIterator = beanManager.getBeans(
+                MVPPresenter.class).iterator();
+        while (beanIterator.hasNext()) {
+            final Bean<?> bean = beanIterator.next();
+            if (bean.getBeanClass().getAnnotation(
+                    ViewInterface.class) == null) {
+                event.addDeploymentProblem(new IllegalArgumentException(
+                        bean.getBeanClass().getName()
+                        + " must be annoteded with @ViewInterface annotation"));
+            }
+            // Should we also check that we added the Observer method ?
+        }
+    }
+
+    public <X> void onProcessManagedBean(@Observes final ProcessManagedBean<X> event,
+            final BeanManager beanManager) {
+
+        if (MVPPresenter.class.isAssignableFrom(event.getBean().getBeanClass())) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST,
+                        "MVPExtension.onProcessManagedBean  found presenter bean {0}",
+                        event.getBean().getBeanClass());
+            }
+            presenterBeans.add(event.getBean());
+        }
+    }
+
+    /*
+     * We probably only need onProcessManagedBean
+     */
+    public <X> void onProcessBean(@Observes final ProcessBean<X> event,
+            final BeanManager beanManager) {
+
+        if (MVPPresenter.class.isAssignableFrom(event.getBean().getBeanClass())) {
+            if (LOGGER.isLoggable(Level.FINEST)) {
+                LOGGER.log(Level.FINEST,
+                        "MVPExtension.onProcessBean  found presenter bean {0}",
+                        event.getBean().getBeanClass());
+            }
+            presenterBeans.add(event.getBean());
+        }
+    }
+
     /**
      * Adds a View enter observer method for each bean extending
      * {@link AbstractMVPPresenter}.
-     * 
+     *
      * @param afterBeanDiscovery
      * @param beanManager
      */
@@ -32,8 +95,11 @@ public class MVPExtension implements Extension, Serializable {
             @Observes final AfterBeanDiscovery afterBeanDiscovery,
             final BeanManager beanManager) {
 
-        final Iterator<Bean<?>> beanIterator = beanManager.getBeans(
-                MVPPresenter.class).iterator();
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.log(Level.FINEST,
+                    "MVPExtension.afterBeanDiscovery  {0}", presenterBeans);
+        }
+        final Iterator<Bean<?>> beanIterator = presenterBeans.iterator();
         while (beanIterator.hasNext()) {
             final Bean<?> bean = beanIterator.next();
             afterBeanDiscovery
@@ -52,9 +118,9 @@ public class MVPExtension implements Extension, Serializable {
                                         "@ViewInterface must be declared for Presenters");
                             }
                             final Class<? extends MVPView> viewInterface = getBeanClass()
-                                    .getAnnotation(ViewInterface.class).value();
+                            .getAnnotation(ViewInterface.class).value();
                             qualifiers.add(new CDIEventImpl(viewInterface
-                                    .getName() + AbstractMVPPresenter.VIEW_ENTER));
+                                            .getName() + AbstractMVPPresenter.VIEW_ENTER));
                             return qualifiers;
                         }
 


### PR DESCRIPTION
...eanDiscovery event

Instead of calling BeanManager.getBeans() , we accumulate the beans we want to enhance during  ProcessBean event, then AfterBeanDiscovery we process the list of Beans
